### PR TITLE
Comment out unimplemented check

### DIFF
--- a/src/shader_recompiler/backend/spirv/emit_spirv_image.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_image.cpp
@@ -196,8 +196,11 @@ Id Texture(EmitContext& ctx, IR::TextureInstInfo info, [[maybe_unused]] const IR
 }
 
 Id TextureImage(EmitContext& ctx, IR::TextureInstInfo info, const IR::Value& index) {
-    if (!index.IsImmediate() || index.U32() != 0) {
-        throw NotImplementedException("Indirect image indexing");
+    // if (!index.IsImmediate() || index.Type() != Shader::IR::Type::U32 || index.U32() != 0) {
+    //     throw NotImplementedException("Indirect image indexing");
+    // }
+    if (index.Type() != Shader::IR::Type::U32) {
+        LOG_WARNING(Shader_SPIRV, "Non-U32 type provided as index: {}", index.Type());
     }
     if (info.type == TextureType::Buffer) {
         const TextureBufferDefinition& def{ctx.texture_buffers.at(info.descriptor_index)};
@@ -215,8 +218,11 @@ Id TextureImage(EmitContext& ctx, IR::TextureInstInfo info, const IR::Value& ind
 }
 
 std::pair<Id, bool> Image(EmitContext& ctx, const IR::Value& index, IR::TextureInstInfo info) {
-    if (!index.IsImmediate() || index.U32() != 0) {
-        throw NotImplementedException("Indirect image indexing");
+    // if (!index.IsImmediate() || index.Type() != Shader::IR::Type::U32 || index.U32() != 0) {
+    //     throw NotImplementedException("Indirect image indexing");
+    // }
+    if (index.Type() != Shader::IR::Type::U32) {
+        LOG_WARNING(Shader_SPIRV, "Non-U32 type provided as index: {}", index.Type());
     }
     if (info.type == TextureType::Buffer) {
         const ImageBufferDefinition def{ctx.image_buffers.at(info.descriptor_index)};


### PR DESCRIPTION
In my testing on macOS, MK8 sometimes crashed at this function, giving a void type instead of u32. I've temporarily commented this out until (if) this is implemented and added a check for if it is implemented